### PR TITLE
Now footer moves as text gets bigger

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -27,8 +27,8 @@ body {
 }
 
 .container {
-  max-width: 1200px;
-  margin: auto;
+  display: flex;
+  flex-direction: column;
 }
 header {
   padding: 0 1em;
@@ -62,6 +62,11 @@ input[type="text"] {
 .controls{
   padding: 16px;
 }
+
+.images {
+  padding-bottom:60px;
+}
+
 .img {
   width: 60px;
   height: 60px;
@@ -82,14 +87,8 @@ input[type="text"] {
 }
 
 footer {
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  margin: auto;
-  text-align: center;
-  padding: 2em 0;
-
+  flex-shrink: 0;
+  padding: 10px;
   a {
     text-decoration: none;
     color: #333;


### PR DESCRIPTION
Footer used to overlay text when this got too long. Now it doesn't anymore. 
Before:
![image](https://user-images.githubusercontent.com/20881323/50808893-761b0500-12df-11e9-9a77-1a1a17f02d1d.png)
After:
![image](https://user-images.githubusercontent.com/20881323/50808919-9a76e180-12df-11e9-9c97-bf052308fe3a.png)
